### PR TITLE
problem about USBPorts.kext

### DIFF
--- a/EFI/OC/Kexts/USBPorts.kext/Contents/Info.plist
+++ b/EFI/OC/Kexts/USBPorts.kext/Contents/Info.plist
@@ -55,7 +55,7 @@
 					<key>XX02</key>
 					<dict>
 						<key>UsbConnector</key>
-						<integer>3</integer>
+						<integer>0</integer>
 						<key>name</key>
 						<string>XX02</string>
 						<key>port</key>
@@ -77,7 +77,7 @@
 					<key>XX08</key>
 					<dict>
 						<key>UsbConnector</key>
-						<integer>0</integer>
+						<integer>3</integer>
 						<key>name</key>
 						<string>XX08</string>
 						<key>port</key>
@@ -88,7 +88,7 @@
 					<key>XX10</key>
 					<dict>
 						<key>UsbConnector</key>
-						<integer>0</integer>
+						<integer>3</integer>
 						<key>name</key>
 						<string>XX10</string>
 						<key>port</key>


### PR DESCRIPTION
Port 0x02 might be USB2.
But the port 0x02 in USBPorts.kext is USB3 now.
This will cause my wireless mouse receiver to not work, and Card Reader on port 0x12 not work.
I changed that type of port 0x02 to USB2, my wireless mouse receiver and Card Reader can work now.

If you plug USB2 and USB3 deivce in USB hub same time, and plug the USB hub into the surface,
The USB2 device will work on port 2(0x02) and USB3 device will work on port 18(0x12).

So I think except 0x04 is already TypeC that no problem,
port 0x02 might be USB2,
And all of another port might be USB3. (port 8 to 18 is using USB3 that show on AIDA64)