### PR TITLE
Adds support for Type Cover 3

### DIFF
--- a/EFI/OC/Kexts/TypeCover3.kext/Contents/Info.plist
+++ b/EFI/OC/Kexts/TypeCover3.kext/Contents/Info.plist
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildMachineOSBuild</key>
+	<string>14C99</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleGetInfoString</key>
+	<string>2.2.0, Type Cover 3 Driver for Surface Pro 3.</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.mykext.TypeCover3</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>I/O Kit Driver for Type Cover 3 USB HID Devices</string>
+	<key>CFBundlePackageType</key>
+	<string>KEXT</string>
+	<key>CFBundleShortVersionString</key>
+	<string>2.2.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>2.2.0</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2015 gkarg. All rights reserved.</string>
+	<key>IOKitPersonalities</key>
+	<dict>
+		<key>Generic Keyboard</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.apple.iokit.IOUSBHIDDriver</string>
+			<key>HIDDefaultBehavior</key>
+			<string></string>
+			<key>IOClass</key>
+			<string>IOUSBHIDDriver</string>
+			<key>IOProviderClass</key>
+			<string>IOUSBInterface</string>
+			<key>bInterfaceClass</key>
+			<integer>3</integer>
+			<key>bInterfaceProtocol</key>
+			<integer>0</integer>
+			<key>bInterfaceSubClass</key>
+			<integer>3</integer>
+			<key>ProductID</key>
+			<integer>2012</integer>					
+			<key>VendorID</key>
+			<integer>1118</integer>						
+		</dict>
+	</dict>
+	<key>OSBundleCompatibleVersion</key>
+	<string>1.8</string>	
+	<key>OSBundleLibraries</key>
+	<dict>
+		<key>com.apple.iokit.IOHIDFamily</key>
+		<string>1.6</string>
+		<key>com.apple.iokit.IOUSBFamily</key>
+		<string>4.1.5</string>
+		<key>com.apple.kpi.bsd</key>
+		<string>10.4.2</string>
+		<key>com.apple.kpi.iokit</key>
+		<string>10.4.2</string>
+		<key>com.apple.kpi.libkern</key>
+		<string>10.4.2</string>
+		<key>com.apple.kpi.mach</key>
+		<string>10.4.2</string>
+	</dict>
+	<key>OSBundleRequired</key>
+	<string>Console</string>
+</dict>
+</plist>

--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -478,6 +478,24 @@
 				<key>PlistPath</key>
 				<string>Contents/Info.plist</string>
 			</dict>
+			<dict>
+				<key>Arch</key>
+				<string>Any</string>
+				<key>BundlePath</key>
+				<string>TypeCover3.kext</string>
+				<key>Comment</key>
+				<string></string>
+				<key>Enabled</key>
+				<true/>
+				<key>ExecutablePath</key>
+				<string></string>
+				<key>MaxKernel</key>
+				<string></string>
+				<key>MinKernel</key>
+				<string></string>
+				<key>PlistPath</key>
+				<string>Contents/Info.plist</string>
+			</dict>
 		</array>
 		<key>Block</key>
 		<array/>


### PR DESCRIPTION
Introducing the support for the old version of Type Cover (the one with the keys with no gaps).

This Type Cover supports only three fingers so for better performance it's better to change the following settings in the MacOS:

Swipe between full-screen applications: Swipe Left or Right with THREE fingers

Misson Control: Swipe Up with THREE fingers