### PR TITLE
degrade airportitlwm to stable version

### DIFF
--- a/EFI/OC/Kexts/AirportItlwm.kext/Contents/Info.plist
+++ b/EFI/OC/Kexts/AirportItlwm.kext/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>BuildMachineOSBuild</key>
-	<string>21G217</string>
+	<string>19H1419</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
@@ -17,29 +17,27 @@
 	<key>CFBundlePackageType</key>
 	<string>KEXT</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.0</string>
+	<string>2.1.0</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
 		<string>MacOSX</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2.2.0</string>
+	<string>2.1.0</string>
 	<key>DTCompiler</key>
 	<string>com.apple.compilers.llvm.clang.1_0</string>
 	<key>DTPlatformBuild</key>
-	<string>14A400</string>
-	<key>DTPlatformName</key>
-	<string>macosx</string>
+	<string>11A420a</string>
 	<key>DTPlatformVersion</key>
-	<string>12.3</string>
+	<string>GM</string>
 	<key>DTSDKBuild</key>
-	<string>21E226</string>
+	<string>19A547</string>
 	<key>DTSDKName</key>
-	<string>macosx12.3</string>
+	<string>macosx10.15</string>
 	<key>DTXcode</key>
-	<string>1401</string>
+	<string>1100</string>
 	<key>DTXcodeBuild</key>
-	<string>14A400</string>
+	<string>11A420a</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>itlwm</key>
@@ -64,8 +62,8 @@
 	<string>Copyright © 2020 钟先耀. All rights reserved.</string>
 	<key>OSBundleLibraries</key>
 	<dict>
-		<key>com.apple.iokit.IO80211FamilyLegacy</key>
-		<string>600.0</string>
+		<key>com.apple.iokit.IO80211Family</key>
+		<string>1200.12.2b1</string>
 		<key>com.apple.iokit.IONetworkingFamily</key>
 		<string>3.2</string>
 		<key>com.apple.iokit.IOPCIFamily</key>

--- a/EFI/OC/Kexts/AirportItlwm.kext/Contents/Info.plist
+++ b/EFI/OC/Kexts/AirportItlwm.kext/Contents/Info.plist
@@ -62,8 +62,8 @@
 	<string>Copyright © 2020 钟先耀. All rights reserved.</string>
 	<key>OSBundleLibraries</key>
 	<dict>
-		<key>com.apple.iokit.IO80211Family</key>
-		<string>1200.12.2b1</string>
+		<key>com.apple.iokit.IO80211FamilyLegacy</key>
+		<string>600.0</string>
 		<key>com.apple.iokit.IONetworkingFamily</key>
 		<string>3.2</string>
 		<key>com.apple.iokit.IOPCIFamily</key>


### PR DESCRIPTION
The 2.2.0 pre-release version of airportitlwm isn't compatible with AX201 wireless card, I believe this is the cause to issue #91 and #46. After switching to itlwm, the bluetooth breaks on my machine. Besides, itlwm [doesn't support WPA2 enterprise WIFI](https://github.com/OpenIntelWireless/HeliPort/issues/212), while switching to 2.1.0 version of airportitlwm solves all these issues.

Since this EFI set is for Monterey, I used [AirportItlwm_v2.1.0_stable_Monterey.kext.zip](https://github.com/OpenIntelWireless/itlwm/releases/download/v2.1.0/AirportItlwm_v2.1.0_stable_Monterey.kext.zip) 

Tested on a sp7 with i5 1035G