### PR TITLE
Battery to be correctly shown in Ventura system settings

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -97,6 +97,36 @@
 				<key>TableSignature</key>
 				<data>RFNEVA==</data>
 			</dict>
+			<dict>
+				<key>Base</key>
+				<string></string>
+				<key>BaseSkip</key>
+				<integer>0</integer>
+				<key>Comment</key>
+				<string>Rename PM Profile</string>
+				<key>Count</key>
+				<integer>0</integer>
+				<key>Enabled</key>
+				<true/>
+				<key>Find</key>
+				<data>AAgJALIAAADw8Q==</data>
+				<key>Limit</key>
+				<integer>0</integer>
+				<key>Mask</key>
+				<data></data>
+				<key>OemTableId</key>
+				<data></data>
+				<key>Replace</key>
+				<data>AAIJALIAAADw8Q==</data>
+				<key>ReplaceMask</key>
+				<data></data>
+				<key>Skip</key>
+				<integer>0</integer>
+				<key>TableLength</key>
+				<integer>0</integer>
+				<key>TableSignature</key>
+				<data>RkFDUA==</data>
+			</dict>
 		</array>
 		<key>Quirks</key>
 		<dict>


### PR DESCRIPTION
Credit goes to @he1833 who proposed this patch in the BigSurface repo: https://github.com/Xiashangning/BigSurface/issues/93

It is mentioned in the Readme of the repo but not yet included into their release. 

Tested in Ventura – before: didn't show battery settings in System Settings; after: shows Battery settings correctly.
Tested in Monterey – battery is indicated as before (aka didn't break anything).


